### PR TITLE
Configurable minWidth and styling in constructor

### DIFF
--- a/Example/MYTableViewIndex.xcodeproj/project.pbxproj
+++ b/Example/MYTableViewIndex.xcodeproj/project.pbxproj
@@ -473,6 +473,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -518,6 +519,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.2;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -538,7 +540,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "my.MYTableViewIndex-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -558,7 +560,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "my.MYTableViewIndex-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/Example/MYTableViewIndex/AppDelegate.swift
+++ b/Example/MYTableViewIndex/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }

--- a/Example/MYTableViewIndex/CollectionViewController.swift
+++ b/Example/MYTableViewIndex/CollectionViewController.swift
@@ -72,7 +72,7 @@ class CollectionViewController : UICollectionViewController, UICollectionViewDel
             return false;
         }
         let indexPath = IndexPath(row: 0, section: sectionIndex)
-        guard let attrs = collectionView.layoutAttributesForSupplementaryElement(ofKind: UICollectionElementKindSectionHeader, at: indexPath) else {
+        guard let attrs = collectionView.layoutAttributesForSupplementaryElement(ofKind: UICollectionView.elementKindSectionHeader, at: indexPath) else {
             return false
         }
         var contentInset: UIEdgeInsets

--- a/Example/MYTableViewIndex/TableViewController.swift
+++ b/Example/MYTableViewIndex/TableViewController.swift
@@ -146,7 +146,7 @@ class TableViewController : UITableViewController, UITextFieldDelegate, TableVie
             str += "i"
             size = str.boundingRect(with: CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude),
                                             options: [.usesFontLeading, .usesLineFragmentOrigin],
-                                            attributes: [NSAttributedStringKey.font: UIFont.boldSystemFont(ofSize: 11.0)],
+                                            attributes: [NSAttributedString.Key.font: UIFont.boldSystemFont(ofSize: 11.0)],
                                             context: nil).size
         }
         return str

--- a/Example/MYTableViewIndex/ViewController.swift
+++ b/Example/MYTableViewIndex/ViewController.swift
@@ -49,9 +49,9 @@ class ViewController: UIViewController, UITableViewDataSource, TableViewIndexDat
         
         setNativeIndexHidden(true)
         
-        NotificationCenter.default.addObserver(self, selector: #selector(ViewController.handleKeyboardNotification(_:)), name: NSNotification.Name.UIKeyboardWillShow, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(ViewController.handleKeyboardNotification(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
         
-        NotificationCenter.default.addObserver(self, selector: #selector(ViewController.handleKeyboardNotification(_:)), name: NSNotification.Name.UIKeyboardWillHide, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(ViewController.handleKeyboardNotification(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
     }
     
     deinit {
@@ -79,7 +79,7 @@ class ViewController: UIViewController, UITableViewDataSource, TableViewIndexDat
     }
     
     func tableView(_ tableView: UITableView, sectionForSectionIndexTitle title: String, at index: Int) -> Int {
-        if title == UITableViewIndexSearch {
+        if title == UITableView.indexSearch {
             tableView.scrollRectToVisible(searchController.searchBar.frame, animated: false)
             return NSNotFound
         } else {
@@ -91,7 +91,7 @@ class ViewController: UIViewController, UITableViewDataSource, TableViewIndexDat
     func sectionIndexTitles(for tableView: UITableView) -> [String]? {
         var titles = UILocalizedIndexedCollation.current().sectionIndexTitles
         if hasSearchIndex {
-            titles.insert(UITableViewIndexSearch, at: 0)
+            titles.insert(UITableView.indexSearch, at: 0)
         }
         return titles
     }
@@ -143,15 +143,15 @@ class ViewController: UIViewController, UITableViewDataSource, TableViewIndexDat
             return
         }
         
-        if let frame = (userInfo[UIKeyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue,
-            let curve = (userInfo[UIKeyboardAnimationCurveUserInfoKey] as? NSNumber)?.intValue,
-            let duration = (userInfo[UIKeyboardAnimationDurationUserInfoKey] as? NSNumber)?.doubleValue {
+        if let frame = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue,
+            let curve = (userInfo[UIResponder.keyboardAnimationCurveUserInfoKey] as? NSNumber)?.intValue,
+            let duration = (userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? NSNumber)?.doubleValue {
             
             let convertedFrame = view.convert(frame, from: nil)
             self.bottomConstraint.constant += (tableView.frame.maxY - convertedFrame.minY)
             
             UIView.animate(withDuration: duration, animations: {
-                UIView.setAnimationCurve(UIViewAnimationCurve(rawValue: curve)!)
+                UIView.setAnimationCurve(UIView.AnimationCurve(rawValue: curve)!)
                 self.view.layoutIfNeeded()
             })
         }

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -587,7 +587,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -702,7 +702,7 @@
 				PRODUCT_NAME = MYTableViewIndex;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/MYTableViewIndex/Private/Style.swift
+++ b/MYTableViewIndex/Private/Style.swift
@@ -15,37 +15,44 @@ class Style : IndexItemAttributes {
     let itemSpacing: CGFloat
     let indexInset: UIEdgeInsets
     let indexOffset: UIOffset
+    let minWidth: CGFloat
     
     init(userInterfaceDirection: UIUserInterfaceLayoutDirection,
-         font: UIFont = StyleDefaults.font,
-         itemSpacing: CGFloat = StyleDefaults.itemSpacing,
-         indexInset: UIEdgeInsets = StyleDefaults.indexInset,
-         indexOffset: UIOffset = StyleDefaults.indexOffset) {
+         font: UIFont? = nil,
+         itemSpacing: CGFloat? = nil,
+         indexInset: UIEdgeInsets? = nil,
+         indexOffset: UIOffset? = nil,
+         minWidth: CGFloat? = nil) {
         self.userInterfaceDirection = userInterfaceDirection
-        self.font = font
-        self.itemSpacing = itemSpacing
-        self.indexInset = indexInset
-        self.indexOffset = indexOffset
+        self.font = font ?? StyleDefaults.font
+        self.itemSpacing = itemSpacing ?? StyleDefaults.itemSpacing
+        self.indexInset = indexInset ?? StyleDefaults.indexInset
+        self.indexOffset = indexOffset ?? StyleDefaults.indexOffset
+        self.minWidth = minWidth ?? StyleDefaults.minWidth
     }
     
     func copy(applying userInterfaceDirection: UIUserInterfaceLayoutDirection) -> Style {
-        return Style(userInterfaceDirection: userInterfaceDirection, font: font, itemSpacing: itemSpacing, indexInset: indexInset, indexOffset: indexOffset)
+        return Style(userInterfaceDirection: userInterfaceDirection, font: font, itemSpacing: itemSpacing, indexInset: indexInset, indexOffset: indexOffset, minWidth: minWidth)
     }
     
     func copy(applying font: UIFont) -> Style {
-        return Style(userInterfaceDirection: userInterfaceDirection, font: font, itemSpacing: itemSpacing, indexInset: indexInset, indexOffset: indexOffset)
+        return Style(userInterfaceDirection: userInterfaceDirection, font: font, itemSpacing: itemSpacing, indexInset: indexInset, indexOffset: indexOffset, minWidth: minWidth)
     }
     
     func copy(applying itemSpacing: CGFloat) -> Style {
-        return Style(userInterfaceDirection: userInterfaceDirection, font: font, itemSpacing: itemSpacing, indexInset: indexInset, indexOffset: indexOffset)
+        return Style(userInterfaceDirection: userInterfaceDirection, font: font, itemSpacing: itemSpacing, indexInset: indexInset, indexOffset: indexOffset, minWidth: minWidth)
     }
 
     func copy(applying indexInset: UIEdgeInsets) -> Style {
-        return Style(userInterfaceDirection: userInterfaceDirection, font: font, itemSpacing: itemSpacing, indexInset: indexInset, indexOffset: indexOffset)
+        return Style(userInterfaceDirection: userInterfaceDirection, font: font, itemSpacing: itemSpacing, indexInset: indexInset, indexOffset: indexOffset, minWidth: minWidth)
     }
 
     func copy(applying indexOffset: UIOffset) -> Style {
-        return Style(userInterfaceDirection: userInterfaceDirection, font: font, itemSpacing: itemSpacing, indexInset: indexInset, indexOffset: indexOffset)
+        return Style(userInterfaceDirection: userInterfaceDirection, font: font, itemSpacing: itemSpacing, indexInset: indexInset, indexOffset: indexOffset, minWidth: minWidth)
+    }
+
+    func copy(applyingMinWidth minWidth: CGFloat) -> Style {
+        return Style(userInterfaceDirection: userInterfaceDirection, font: font, itemSpacing: itemSpacing, indexInset: indexInset, indexOffset: indexOffset, minWidth: minWidth)
     }
 }
 
@@ -60,4 +67,5 @@ struct StyleDefaults {
                                          bottom: CGFloat.greatestFiniteMagnitude, right: 1.0)
     
     static let indexOffset = UIOffset()
+    static let minWidth: CGFloat = 44.0
 }

--- a/MYTableViewIndex/Public/TableViewIndex.swift
+++ b/MYTableViewIndex/Public/TableViewIndex.swift
@@ -41,6 +41,13 @@ open class TableViewIndex : UIControl {
         get { return style.font }
         set { style = style.copy(applying: newValue) }
     }
+
+    /// Minimum width of the view. Equals to 44 points by default to enable easy tapping
+    /// Use resetMinWidth to fall back to default spacing.
+    public var minWidth: CGFloat {
+        get { return style.minWidth }
+        set { style = style.copy(applyingMinWidth: minWidth) }
+    }
     
     /// Vertical spacing between the items. Equals to 1 point by default to match system appearance.
     /// Use resetItemSpacing to fall back to default spacing.
@@ -83,6 +90,10 @@ open class TableViewIndex : UIControl {
     }
     
     private var truncation: Truncation<UIView>?
+    
+    func setStyle(_ style:Style) {
+        self.style = style
+    }
     
     private var style: Style! {
         didSet {
@@ -219,7 +230,7 @@ open class TableViewIndex : UIControl {
     override open var intrinsicContentSize: CGSize {
         let layout = ItemLayout(items: items, style: style)
         let width = layout.size.width + style.indexInset.left + style.indexInset.right
-        let minWidth: CGFloat = 44.0
+        let minWidth: CGFloat = CGFloat(self.minWidth)
         return CGSize(width: max(width, minWidth), height: UIViewNoIntrinsicMetric)
     }
     

--- a/MYTableViewIndex/Public/TableViewIndex.swift
+++ b/MYTableViewIndex/Public/TableViewIndex.swift
@@ -129,7 +129,7 @@ open class TableViewIndex : UIControl {
         isExclusiveTouch = true
         isMultipleTouchEnabled = false
         isAccessibilityElement = true
-        accessibilityTraits = UIAccessibilityTraitAdjustable
+        accessibilityTraits = UIAccessibilityTraits.adjustable
         accessibilityLabel = NSLocalizedString("Table index", comment: "Accessibility title for the section index control")
     }
     
@@ -196,7 +196,7 @@ open class TableViewIndex : UIControl {
         }
         
         let selectedText = NSLocalizedString("Selected", comment: "Accessibility title for the selected state")
-        UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, "\(titleText), \(selectedText)")
+        UIAccessibility.post(notification: UIAccessibility.Notification.announcement, argument: "\(titleText), \(selectedText)")
     }
         
     // MARK: - Layout
@@ -231,7 +231,7 @@ open class TableViewIndex : UIControl {
         let layout = ItemLayout(items: items, style: style)
         let width = layout.size.width + style.indexInset.left + style.indexInset.right
         let minWidth: CGFloat = CGFloat(self.minWidth)
-        return CGSize(width: max(width, minWidth), height: UIViewNoIntrinsicMetric)
+        return CGSize(width: max(width, minWidth), height: UIView.noIntrinsicMetric)
     }
     
     open override func sizeThatFits(_ size: CGSize) -> CGSize {

--- a/MYTableViewIndex/Public/TableViewIndexController.swift
+++ b/MYTableViewIndex/Public/TableViewIndexController.swift
@@ -79,9 +79,9 @@ public class TableViewIndexController : NSObject {
     // MARK: - Keyboard
     
     private func observeKeyboard() {
-        NotificationCenter.default.addObserver(self, selector: #selector(TableViewIndexController.handleKeyboardNotification(_:)), name: NSNotification.Name.UIKeyboardWillShow, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(TableViewIndexController.handleKeyboardNotification(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
         
-        NotificationCenter.default.addObserver(self, selector: #selector(TableViewIndexController.handleKeyboardNotification(_:)), name: NSNotification.Name.UIKeyboardWillHide, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(TableViewIndexController.handleKeyboardNotification(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
     }
     
     @objc private func handleKeyboardNotification(_ note: Notification) {
@@ -89,9 +89,9 @@ public class TableViewIndexController : NSObject {
             return;
         }
         
-        if let frame = (userInfo[UIKeyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue,
-           let curve = (userInfo[UIKeyboardAnimationCurveUserInfoKey] as? NSNumber)?.intValue,
-           let duration = (userInfo[UIKeyboardAnimationDurationUserInfoKey] as? NSNumber)?.doubleValue {
+        if let frame = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue,
+            let curve = (userInfo[UIResponder.keyboardAnimationCurveUserInfoKey] as? NSNumber)?.intValue,
+            let duration = (userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? NSNumber)?.doubleValue {
             
             let convertedFrame = parentView.convert(frame, from: nil)
             
@@ -104,7 +104,7 @@ public class TableViewIndexController : NSObject {
             inset.bottom = max(scrollView.frame.maxY - convertedFrame.minY, safeAreaInsets.bottom)
             
             UIView.animate(withDuration: duration, animations: {
-                UIView.setAnimationCurve(UIViewAnimationCurve(rawValue: curve)!)
+                UIView.setAnimationCurve(UIView.AnimationCurve(rawValue: curve)!)
 
                 self.layout(with: inset)
                 parentView.layoutIfNeeded()

--- a/MYTableViewIndex/Public/TableViewIndexController.swift
+++ b/MYTableViewIndex/Public/TableViewIndexController.swift
@@ -31,8 +31,10 @@ public class TableViewIndexController : NSObject {
     
     private var hidden = false
     
-    public init(scrollView: UIScrollView) {
+    public init(scrollView: UIScrollView, font: UIFont? = nil, itemSpacing: CGFloat? = nil, indexInset: UIEdgeInsets? = nil, indexOffset: UIOffset? = nil, minWidth: CGFloat? = nil) {
         self.scrollView = scrollView
+        let style = Style(userInterfaceDirection:UIView.my_userInterfaceLayoutDirection(for: scrollView), font:font, itemSpacing:itemSpacing,indexInset:indexInset, indexOffset: indexOffset, minWidth: minWidth)
+        tableViewIndex.setStyle(style)
         super.init()
         
         observeScrollView()


### PR DESCRIPTION
This PR adds configurable minWidth instead of hardcoded 44 points, and extends the TableViewIndexController constructor with styling options so that you don't have to do styling like this: tableViewIndexController.tableViewIndex.font = UIFont.boldSystemFont(ofSize: 12.0)