### PR TITLE
Correct handling for changing the minWidth of the index

### DIFF
--- a/MYTableViewIndex/Public/TableViewIndex.swift
+++ b/MYTableViewIndex/Public/TableViewIndex.swift
@@ -46,7 +46,7 @@ open class TableViewIndex : UIControl {
     /// Use resetMinWidth to fall back to default spacing.
     public var minWidth: CGFloat {
         get { return style.minWidth }
-        set { style = style.copy(applyingMinWidth: minWidth) }
+        set { style = style.copy(applyingMinWidth: newValue) }
     }
     
     /// Vertical spacing between the items. Equals to 1 point by default to match system appearance.


### PR DESCRIPTION
When updating the minWidth, the current(old) value was being used to create the new style. 