### PR TITLE
Resolve modal presentation conflicts with dismiss pan gesture

### DIFF
--- a/MYTableViewIndex/Public/TableViewIndex.swift
+++ b/MYTableViewIndex/Public/TableViewIndex.swift
@@ -302,6 +302,15 @@ open class TableViewIndex : UIControl {
         isHighlighted = false
         cleanupFeedbackGenerator()
     }
+
+    // Prevent iOS 13 modal pan gesture (or really any pan gesture) from firing when touched
+    open override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        if let _ = gestureRecognizer.self as? UIPanGestureRecognizer {
+            return false
+        } else {
+            return true
+        }
+    }
     
     // MARK: - Haptic Feedback support
     


### PR DESCRIPTION
Resolves an issue where iOS 13's modal pan gesture conflicted with MyTableViewIndex touches. Enjoy :) 